### PR TITLE
Add failsafe for a missing fluid on world load

### DIFF
--- a/src/main/java/com/lordmau5/ffs/tile/abstracts/AbstractTankValve.java
+++ b/src/main/java/com/lordmau5/ffs/tile/abstracts/AbstractTankValve.java
@@ -732,7 +732,13 @@ public abstract class AbstractTankValve extends AbstractTankTile implements IFac
             isValid = tag.getBoolean("isValid");
             if(tag.getBoolean("hasFluid")) {
                 if(tag.hasKey("fluidName"))
-                    fluidStack = new FluidStack(FluidRegistry.getFluid(tag.getString("fluidName")), tag.getInteger("fluidAmount"));
+                    try
+                        fluidStack = new FluidStack(FluidRegistry.getFluid(tag.getString("fluidName")), tag.getInteger("fluidAmount"));
+                    catch (IllegalArgumentException e) {
+                        System.out.println("Unable to load fluid: "+tag.getString("fluidName"));
+                        e.printStackTrace();
+                    }
+                        
 
                 updateFluidTemperature();
             }

--- a/src/main/java/com/lordmau5/ffs/tile/abstracts/AbstractTankValve.java
+++ b/src/main/java/com/lordmau5/ffs/tile/abstracts/AbstractTankValve.java
@@ -732,15 +732,12 @@ public abstract class AbstractTankValve extends AbstractTankTile implements IFac
             isValid = tag.getBoolean("isValid");
             if(tag.getBoolean("hasFluid")) {
                 if(tag.hasKey("fluidName"))
-                    try
+                    try {
                         fluidStack = new FluidStack(FluidRegistry.getFluid(tag.getString("fluidName")), tag.getInteger("fluidAmount"));
-                    catch (IllegalArgumentException e) {
+                        updateFluidTemperature();
+                    } catch (IllegalArgumentException e) {
                         System.out.println("Unable to load fluid: "+tag.getString("fluidName"));
-                        e.printStackTrace();
                     }
-                        
-
-                updateFluidTemperature();
             }
             else {
                 fluidStack = null;


### PR DESCRIPTION
As is, the game crashes when FFS attempts to load up a tank when the fluid inside it is not registered in the fluid registry. This simply catches that and allows it to continue loading, albeit deleting the fluid from the tank along the way. Perhaps checking if it is registered will remove some overhead, but I was too tired to look up the fluid registry API when I forked this. I just wanted my world to load.
